### PR TITLE
VertexProperty internals refactor

### DIFF
--- a/goblin/abc.py
+++ b/goblin/abc.py
@@ -1,0 +1,23 @@
+import abc
+
+
+class DataType(abc.ABC):
+
+    @abc.abstractmethod
+    def validate(self):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def to_db(self, val):
+        return val
+
+    @abc.abstractmethod
+    def to_ogm(self, val):
+        return val
+
+
+class BaseProperty:
+
+    @property
+    def data_type(self):
+        raise NotImplementedError

--- a/goblin/api.py
+++ b/goblin/api.py
@@ -272,12 +272,10 @@ class Edge(meta.Element):
 
 class VertexProperty(meta.Element, abc.BaseProperty):
 
-    __data_type__ = None
-
     def __init__(self, data_type, *, value=None, default=None):
         if isinstance(data_type, type):
             data_type = data_type()
-        self.__data_type__ = data_type
+        self._data_type = data_type
         self._value = value
         self._default = default
 
@@ -287,7 +285,7 @@ class VertexProperty(meta.Element, abc.BaseProperty):
 
     @property
     def data_type(self):
-        return self.__data_type__
+        return self._data_type
 
     @property
     def value(self):

--- a/goblin/api.py
+++ b/goblin/api.py
@@ -2,6 +2,7 @@
 import collections
 import logging
 
+from goblin import abc
 from goblin import gremlin_python
 from goblin import driver
 from goblin import mapper
@@ -230,12 +231,12 @@ class Session:
         raise NotImplementedError
 
 
-class Vertex(metaclass=meta.ElementMeta):
+class Vertex(meta.Element):
     """Base class for user defined Vertex classes"""
     pass
 
 
-class Edge(metaclass=meta.ElementMeta):
+class Edge(meta.Element):
     """Base class for user defined Edge classes"""
 
     def __init__(self, source=None, target=None):
@@ -269,7 +270,7 @@ class Edge(metaclass=meta.ElementMeta):
     target = property(gettarget, settarget, deltarget)
 
 
-class VertexProperty(metaclass=meta.ElementMeta):
+class VertexProperty(meta.Element, abc.BaseProperty):
 
     __data_type__ = None
 

--- a/goblin/api.py
+++ b/goblin/api.py
@@ -270,7 +270,42 @@ class Edge(meta.Element):
     target = property(gettarget, settarget, deltarget)
 
 
+class VertexPropertyDescriptor:
+    """Descriptor that validates user property input and gets/sets properties
+       as instance attributes."""
+
+    def __init__(self, name, vertex_property):
+        self._name = '_' + name
+        self._vertex_property = vertex_property.__class__
+        self._data_type = vertex_property.data_type
+        self._default = vertex_property.default
+
+    def __get__(self, obj, objtype):
+        if obj is None:
+            return self._vertex_property
+        default = self._default
+        if default:
+            default = self._data_type.validate(default)
+            default = self._vertex_property(self._default)
+        return getattr(obj, self._name, default)
+
+    def __set__(self, obj, val):
+        if isinstance(val, (list, tuple , set)):
+            vertex_property = []
+            for v in val:
+                v = self._data_type.validate(v)
+                vertex_property.append(
+                    self._vertex_property(self._data_type, value=v))
+
+        else:
+            val = self._data_type.validate(val)
+            vertex_property = self._vertex_property(self._data_type, value=val)
+        setattr(obj, self._name, vertex_property)
+
+
 class VertexProperty(meta.Element, abc.BaseProperty):
+
+    __descriptor__ = VertexPropertyDescriptor
 
     def __init__(self, data_type, *, value=None, default=None):
         if isinstance(data_type, type):
@@ -293,4 +328,4 @@ class VertexProperty(meta.Element, abc.BaseProperty):
 
     def __repr__(self):
         return '<{}(type={}, value={})'.format(self.__class__.__name__,
-                                               self.__data_type__, self.value)
+                                               self._data_type, self.value)

--- a/goblin/mapper.py
+++ b/goblin/mapper.py
@@ -46,20 +46,20 @@ def map_edge_to_ogm(result, element, mapping):
 
 
 # DB <-> OGM Mapping
-def create_mapping(namespace, properties, vertex_properties):
+def create_mapping(namespace, properties):
     """Constructor for :py:class:`Mapping`"""
     if namespace.get('__type__', None):
-        return Mapping(namespace, properties, vertex_properties)
+        return Mapping(namespace, properties)
 
 
 class Mapping:
     """This class stores the information necessary to map between an
        OGM element and a DB element"""
-    def __init__(self, namespace, properties, vertex_properties):
+    def __init__(self, namespace, properties):
         self._label = namespace.get('__label__', None) or self._create_label()
         self._type = namespace['__type__']
         self._properties = []
-        self._map_properties(properties, vertex_properties)
+        self._map_properties(properties)
 
     @property
     def label(self):
@@ -72,7 +72,7 @@ class Mapping:
     def _create_label(self):
         return inflection.underscore(self.__class__.__name__)
 
-    def _map_properties(self, properties, vertex_properties):
+    def _map_properties(self, properties):
         for name, prop in properties.items():
             data_type = prop.data_type
             db_name = '{}__{}'.format(self._label, name)

--- a/goblin/meta.py
+++ b/goblin/meta.py
@@ -24,9 +24,8 @@ class ElementMeta(type):
                 props[k] = v
                 if not isinstance(v, properties.Property):
                     vertex_property = v.__class__
-                    vertex_property.__data_type__ = v.data_type
                     v = properties.VertexPropertyDescriptor(
-                        k, vertex_property, default=v.default)
+                        k, vertex_property, v.data_type, default=v.default)
                 else:
                     v = properties.PropertyDescriptor(
                         k, v.data_type, default=v.default)

--- a/goblin/meta.py
+++ b/goblin/meta.py
@@ -22,13 +22,7 @@ class ElementMeta(type):
         for k, v in namespace.items():
             if isinstance(v, abc.BaseProperty):
                 props[k] = v
-                if not isinstance(v, properties.Property):
-                    vertex_property = v.__class__
-                    v = properties.VertexPropertyDescriptor(
-                        k, vertex_property, v.data_type, default=v.default)
-                else:
-                    v = properties.PropertyDescriptor(
-                        k, v.data_type, default=v.default)
+                v = v.__descriptor__(k, v)
             new_namespace[k] = v
         new_namespace['__mapping__'] = mapper.create_mapping(namespace,
                                                              props)

--- a/goblin/meta.py
+++ b/goblin/meta.py
@@ -1,7 +1,6 @@
 import logging
 
-import inflection
-
+from goblin import abc
 from goblin import mapper
 from goblin import properties
 
@@ -17,28 +16,28 @@ class ElementMeta(type):
        :py:class:`property.PropertyDescriptor`"""
     def __new__(cls, name, bases, namespace, **kwds):
         if bases:
-            namespace['__type__'] = inflection.underscore(bases[0].__name__)
+            namespace['__type__'] = bases[0].__name__.lower()
         props = {}
-        vertex_props = {}
         new_namespace = {}
         for k, v in namespace.items():
-            if isinstance(v, properties.Property):
+            if isinstance(v, abc.BaseProperty):
                 props[k] = v
-                v = properties.PropertyDescriptor(
-                    k, v.data_type, default=v.default)
-            else:
-                element_type = getattr(v, '__type__', None)
-                if element_type == 'vertex_property':
-                    vertex_props[k] = v
-                    vertex_property_class = v.__class__
-                    vertex_property_class.__data_type__ = v.data_type
+                if not isinstance(v, properties.Property):
+                    vertex_property = v.__class__
+                    vertex_property.__data_type__ = v.data_type
                     v = properties.VertexPropertyDescriptor(
-                        k, vertex_property_class, default=v.default)
+                        k, vertex_property, default=v.default)
+                else:
+                    v = properties.PropertyDescriptor(
+                        k, v.data_type, default=v.default)
             new_namespace[k] = v
         new_namespace['__mapping__'] = mapper.create_mapping(namespace,
-                                                             props,
-                                                             vertex_props)
-        logger.info("Creating new Element class {}: {}".format(
+                                                             props)
+        logger.warning("Creating new Element class {}: {}".format(
             name, new_namespace['__mapping__']))
         result = type.__new__(cls, name, bases, new_namespace)
         return result
+
+
+class Element(metaclass=ElementMeta):
+    pass

--- a/goblin/properties.py
+++ b/goblin/properties.py
@@ -11,10 +11,10 @@ class PropertyDescriptor:
     """Descriptor that validates user property input and gets/sets properties
        as instance attributes."""
 
-    def __init__(self, name, data_type, *, default=None):
+    def __init__(self, name, prop):
         self._name = '_' + name
-        self._data_type = data_type
-        self._default = default
+        self._data_type = prop.data_type
+        self._default = prop.default
 
     def __get__(self, obj, objtype):
         if obj is None:
@@ -31,42 +31,11 @@ class PropertyDescriptor:
             del attr
 
 
-class VertexPropertyDescriptor:
-    """Descriptor that validates user property input and gets/sets properties
-       as instance attributes."""
-
-    def __init__(self, name, vertex_property, data_type, *, default=None):
-        self._name = '_' + name
-        self._vertex_property = vertex_property
-        self._data_type = data_type
-        self._default = default
-
-    def __get__(self, obj, objtype):
-        if obj is None:
-            return self._vertex_property
-        default = self._default
-        if default:
-            default = self._data_type.validate(default)
-            default = self._vertex_property(self._default)
-        return getattr(obj, self._name, default)
-
-    def __set__(self, obj, val):
-        if isinstance(val, (list, tuple , set)):
-            vertex_property = []
-            for v in val:
-                v = self._data_type.validate(v)
-                vertex_property.append(
-                    self._vertex_property(self._data_type, value=v))
-
-        else:
-            val = self._data_type.validate(val)
-            vertex_property = self._vertex_property(self._data_type, value=val)
-        setattr(obj, self._name, vertex_property)
-
-
 class Property(abc.BaseProperty):
     """API class used to define properties. Replaced with
       :py:class:`PropertyDescriptor` by :py:class:`api.ElementMeta`."""
+
+    __descriptor__ = PropertyDescriptor
 
     def __init__(self, data_type, *, default=None):
         if isinstance(data_type, type):

--- a/goblin/properties.py
+++ b/goblin/properties.py
@@ -68,8 +68,6 @@ class Property(abc.BaseProperty):
     """API class used to define properties. Replaced with
       :py:class:`PropertyDescriptor` by :py:class:`api.ElementMeta`."""
 
-    descriptor = PropertyDescriptor
-
     def __init__(self, data_type, *, default=None):
         if isinstance(data_type, type):
             data_type = data_type()

--- a/goblin/properties.py
+++ b/goblin/properties.py
@@ -1,7 +1,7 @@
 """Classes to handle proerties and data type definitions"""
-import abc
 import logging
 
+from goblin import abc
 from goblin import mapper
 
 logger = logging.getLogger(__name__)
@@ -58,7 +58,7 @@ class VertexPropertyDescriptor(PropertyDescriptor):
         setattr(obj, self._name, vertex_property)
 
 
-class Property:
+class Property(abc.BaseProperty):
     """API class used to define properties. Replaced with
       :py:class:`PropertyDescriptor` by :py:class:`api.ElementMeta`."""
 
@@ -83,23 +83,8 @@ class Property:
         return self._default
 
 
-class DataType(abc.ABC):
-
-    @abc.abstractmethod
-    def validate(self):
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def to_db(self, val):
-        return val
-
-    @abc.abstractmethod
-    def to_ogm(self, val):
-        return val
-
-
 # Data types
-class String(DataType):
+class String(abc.DataType):
     """Simple string datatype"""
 
     def validate(self, val):

--- a/goblin/properties.py
+++ b/goblin/properties.py
@@ -31,30 +31,36 @@ class PropertyDescriptor:
             del attr
 
 
-class VertexPropertyDescriptor(PropertyDescriptor):
+class VertexPropertyDescriptor:
     """Descriptor that validates user property input and gets/sets properties
        as instance attributes."""
 
+    def __init__(self, name, vertex_property, data_type, *, default=None):
+        self._name = '_' + name
+        self._vertex_property = vertex_property
+        self._data_type = data_type
+        self._default = default
+
     def __get__(self, obj, objtype):
         if obj is None:
-            return self._data_type
+            return self._vertex_property
         default = self._default
         if default:
-            default = self._data_type(self._default)
+            default = self._data_type.validate(default)
+            default = self._vertex_property(self._default)
         return getattr(obj, self._name, default)
 
     def __set__(self, obj, val):
         if isinstance(val, (list, tuple , set)):
             vertex_property = []
             for v in val:
-                v = self._data_type.__data_type__.validate(v)
+                v = self._data_type.validate(v)
                 vertex_property.append(
-                    self._data_type(self._data_type.__data_type__, value=v))
+                    self._vertex_property(self._data_type, value=v))
 
         else:
-            val = self._data_type.__data_type__.validate(val)
-            vertex_property = self._data_type(
-                self._data_type.__data_type__, value=val)
+            val = self._data_type.validate(val)
+            vertex_property = self._vertex_property(self._data_type, value=val)
         setattr(obj, self._name, vertex_property)
 
 
@@ -73,10 +79,6 @@ class Property(abc.BaseProperty):
     @property
     def data_type(self):
         return self._data_type
-
-    @property
-    def vertex_property(self):
-        return self._vertex_property
 
     @property
     def default(self):


### PR DESCRIPTION
This is a simple refactor that makes the VertexProperty internals a bit more easy to reason about. Merge descriptors is a bad name, because I decided I don't want to merge descriptors. 
