### PR TITLE
pass loop explicitly to asyncio.gather in pool, cluster

### DIFF
--- a/goblin/driver/cluster.py
+++ b/goblin/driver/cluster.py
@@ -194,5 +194,5 @@ class Cluster:
         while self._hosts:
             host = self._hosts.popleft()
             waiters.append(host.close())
-        await asyncio.gather(*waiters)
+        await asyncio.gather(*waiters, loop=self._loop)
         self._closed = True

--- a/goblin/driver/pool.py
+++ b/goblin/driver/pool.py
@@ -211,7 +211,7 @@ class ConnectionPool:
         while self._acquired:
             conn = self._acquired.popleft()
             waiters.append(conn.close())
-        await asyncio.gather(*waiters)
+        await asyncio.gather(*waiters, loop=self._loop)
 
     async def _get_connection(self, username, password, max_inflight,
                               response_timeout, message_serializer):


### PR DESCRIPTION
There were a couple of places where the loop wasn't passed explicitly to `asyncio.gather`.
