### PR TITLE
Provider conf

### DIFF
--- a/goblin/app.py
+++ b/goblin/app.py
@@ -21,7 +21,7 @@ import collections
 import importlib
 import logging
 
-from goblin import driver, element, session
+from goblin import driver, element, provider, session
 
 
 logger = logging.getLogger(__name__)
@@ -40,7 +40,7 @@ class Goblin:
     :param dict config: Config parameters for application
     """
 
-    def __init__(self, cluster, *, get_hashable_id=None, aliases=None):
+    def __init__(self, cluster, *, provider=provider.TinkerGraph, get_hashable_id=None, aliases=None):
         self._cluster = cluster
         self._loop = self._cluster._loop
         self._transactions = None
@@ -48,21 +48,23 @@ class Goblin:
         self._vertices = collections.defaultdict(
             lambda: element.GenericVertex)
         self._edges = collections.defaultdict(lambda: element.GenericEdge)
+        self._provider = provider
         if not get_hashable_id:
-            get_hashable_id = lambda x: x
+            get_hashable_id = self._provider.get_hashable_id
         self._get_hashable_id = get_hashable_id
         if aliases is None:
             aliases = {}
         self._aliases = aliases
 
     @classmethod
-    async def open(cls, loop, *, get_hashable_id=None, aliases=None, **config):
+    async def open(cls, loop, *, provider=provider.TinkerGraph, get_hashable_id=None, aliases=None, **config):
         # App currently only supports GraphSON 1
         cluster = await driver.Cluster.open(
             loop, aliases=aliases,
             message_serializer=driver.GraphSONMessageSerializer,
+            provider=provider,
             **config)
-        app = Goblin(cluster, get_hashable_id=get_hashable_id, aliases=aliases)
+        app = Goblin(cluster, provider=provider, get_hashable_id=get_hashable_id, aliases=aliases)
         await app.supports_transactions()
         return app
 

--- a/goblin/driver/cluster.py
+++ b/goblin/driver/cluster.py
@@ -27,7 +27,7 @@ except ImportError:
 
 import yaml
 
-from goblin import driver, exception
+from goblin import driver, exception, provider
 
 
 def my_import(name):
@@ -60,7 +60,8 @@ class Cluster:
         'min_conns': 1,
         'max_times_acquired': 16,
         'max_inflight': 64,
-        'message_serializer': 'goblin.driver.GraphSON2MessageSerializer'
+        'message_serializer': 'goblin.driver.GraphSON2MessageSerializer',
+        'provider': provider.TinkerGraph
     }
 
     def __init__(self, loop, aliases=None, **config):

--- a/goblin/driver/pool.py
+++ b/goblin/driver/pool.py
@@ -113,7 +113,7 @@ class ConnectionPool:
 
     def __init__(self, url, loop, ssl_context, username, password, max_conns,
                  min_conns, max_times_acquired, max_inflight, response_timeout,
-                 message_serializer):
+                 message_serializer, provider):
         self._url = url
         self._loop = loop
         self._ssl_context = ssl_context
@@ -128,6 +128,7 @@ class ConnectionPool:
         self._condition = asyncio.Condition(loop=self._loop)
         self._available = collections.deque()
         self._acquired = collections.deque()
+        self._provider = provider
 
     @property
     def url(self):
@@ -145,7 +146,8 @@ class ConnectionPool:
                                               self._password,
                                               self._max_inflight,
                                               self._response_timeout,
-                                              self._message_serializer)
+                                              self._message_serializer,
+                                              self._provider)
             self._available.append(conn)
 
     def release(self, conn):
@@ -187,7 +189,8 @@ class ConnectionPool:
                     conn = await self._get_connection(username, password,
                                                       max_inflight,
                                                       response_timeout,
-                                                      message_serializer)
+                                                      message_serializer,
+                                                      self._provider)
                     conn.increment_acquired()
                     self._acquired.append(conn)
                     return conn
@@ -214,11 +217,11 @@ class ConnectionPool:
         await asyncio.gather(*waiters, loop=self._loop)
 
     async def _get_connection(self, username, password, max_inflight,
-                              response_timeout, message_serializer):
+                              response_timeout, message_serializer, provider):
         conn = await connection.Connection.open(
             self._url, self._loop, ssl_context=self._ssl_context,
             username=username, password=password,
             response_timeout=response_timeout,
-            message_serializer=message_serializer)
+            message_serializer=message_serializer, provider=provider)
         conn = PooledConnection(conn, self)
         return conn

--- a/goblin/driver/server.py
+++ b/goblin/driver/server.py
@@ -38,6 +38,7 @@ class GremlinServer:
         self._min_conns = config['min_conns']
         self._max_inflight = config['max_inflight']
         self._message_serializer = config['message_serializer']
+        self._provider = config['provider']
         scheme = config['scheme']
         if scheme in ['https', 'wss']:
             certfile = config['ssl_certfile']
@@ -83,7 +84,7 @@ class GremlinServer:
             self._url, self._loop, self._ssl_context, self._username,
             self._password, self._max_conns, self._min_conns,
             self._max_times_acquired, self._max_inflight,
-            self._response_timeout, self._message_serializer)
+            self._response_timeout, self._message_serializer, self._provider)
         await conn_pool.init_pool()
         self._pool = conn_pool
 

--- a/goblin/provider.py
+++ b/goblin/provider.py
@@ -1,0 +1,11 @@
+class Provider:
+    """Superclass for provider plugins"""
+    DEFAULT_OP_ARGS = {}
+
+    @classmethod
+    def get_default_op_args(cls, processor):
+        return cls.DEFAULT_OP_ARGS.get(processor, dict())
+
+
+class TinkerGraph(Provider):  # TODO
+    """Default provider"""

--- a/goblin/provider.py
+++ b/goblin/provider.py
@@ -9,3 +9,6 @@ class Provider:
 
 class TinkerGraph(Provider):  # TODO
     """Default provider"""
+    @staticmethod
+    def get_hashable_id(val):
+        return val

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ import asyncio
 import pytest
 from goblin import Goblin, driver, element, properties, Cardinality
 from goblin.driver import pool, serializer
-from gremlin_python import process
+from goblin import provider
 
 
 def pytest_generate_tests(metafunc):
@@ -85,7 +85,7 @@ def connection(event_loop):
 def connection_pool(event_loop):
     return pool.ConnectionPool(
         "http://localhost:8182/gremlin", event_loop, None, '', '', 4, 1, 16,
-        64, None, serializer.GraphSONMessageSerializer)
+        64, None, serializer.GraphSONMessageSerializer, provider=provider.TinkerGraph)
 
 
 @pytest.fixture

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -25,6 +25,7 @@ from aiohttp import web
 
 from goblin import driver
 from goblin import exception
+from goblin import provider
 
 
 @pytest.mark.asyncio
@@ -149,7 +150,8 @@ async def test_authenticated_connection(event_loop, unused_tcp_port):
             connection = driver.Connection(
                 url=url, ws=ws_client, loop=event_loop, client_session=session,
                 username=username, password=password, max_inflight=64, response_timeout=None,
-                message_serializer=driver.GraphSONMessageSerializer
+                message_serializer=driver.GraphSONMessageSerializer,
+                provider=provider.TinkerGraph
             )
             event_loop.create_task(connection.submit(gremlin="1+1"))
             initial_request = await authentication_request_queue.get()

--- a/tests/test_provider_conf.py
+++ b/tests/test_provider_conf.py
@@ -125,3 +125,14 @@ async def test_conn_default_op_args(event_loop, monkeypatch, processor, key, val
 
     await conn.close()
     resp.close()
+
+
+@pytest.mark.asyncio
+async def test_cluster_conn_provider(event_loop):
+    cluster = await driver.Cluster.open(event_loop, provider=TestProvider)
+    assert cluster.config['provider'] == TestProvider
+
+    pooled_conn = await cluster.get_connection()
+    assert pooled_conn._conn._provider == TestProvider
+
+    await cluster.close()

--- a/tests/test_provider_conf.py
+++ b/tests/test_provider_conf.py
@@ -1,0 +1,128 @@
+import asyncio
+import uuid
+from unittest import mock
+
+import json
+import pytest
+
+import aiohttp
+from aiohttp import websocket_client
+
+from goblin import driver
+from goblin.driver import serializer
+from goblin import provider
+
+request_id = uuid.UUID(int=215449331521667564889692237976543325869, version=4)
+
+
+# based on this handy tip on SO: http://stackoverflow.com/a/29905620/6691423
+def get_mock_coro(return_value):
+    async def mock_coro(*args, **kwargs):
+        return return_value
+
+    return mock.Mock(wraps=mock_coro)
+
+
+async def mock_receive():
+    message = mock.Mock()
+    message.tp = aiohttp.MsgType.close
+    return message
+
+
+async def mock_ws_connect(*args, **kwargs):
+    mock_client = mock.Mock(spec=websocket_client.ClientWebSocketResponse)
+    mock_client.closed = False
+    mock_client.receive = mock.Mock(wraps=mock_receive)
+    mock_client.close = get_mock_coro(None)
+    return mock_client
+
+
+class TestProvider(provider.Provider):
+    DEFAULT_OP_ARGS = {
+        'standard': {
+            'eval': {
+                'fictional_argument': 'fictional_value'
+            },
+        },
+        'session': {
+            'eval': {
+                'manageTransaction': True
+            },
+
+        }
+    }
+
+
+def deserialize_json_request(request):
+    header_len = request[0] + 1
+    payload = request[header_len:]
+    return json.loads(payload.decode())
+
+
+@pytest.fixture(params=(
+        serializer.GraphSONMessageSerializer,
+        serializer.GraphSON2MessageSerializer
+))
+def message_serializer(request):
+    return request.param
+
+
+@pytest.mark.parametrize('processor_name,key,value', (
+        ('standard', 'fictional_argument', 'fictional_value'),
+        ('session', 'manageTransaction', True)
+))
+def test_get_processor_provider_default_args(processor_name, key, value):
+    processor = serializer.GraphSONMessageSerializer.get_processor(TestProvider, processor_name)
+    assert processor._default_args == TestProvider.DEFAULT_OP_ARGS[processor_name]
+    eval_op_method = processor.get_op('eval')
+    eval_args = eval_op_method({'gremlin': 'g.V()'})
+    print(eval_op_method, eval_args)
+    assert eval_args['gremlin'] == 'g.V()'
+    assert eval_args[key] == value
+
+
+@pytest.mark.parametrize('processor,key,value', (
+        ('', 'fictional_argument', 'fictional_value'),
+        ('session', 'manageTransaction', True)
+))
+def test_serializer_default_op_args(message_serializer, processor, key, value):
+    g = driver.AsyncGraph().traversal()
+    traversal = g.V().hasLabel('stuff').has('foo', 'bar')
+    serialized_message = message_serializer.serialize_message(
+        TestProvider, str(uuid.uuid4()), processor=processor, op='eval', gremlin=traversal.bytecode)
+    message = deserialize_json_request(serialized_message)
+    assert message['args'][key] == value
+
+
+@pytest.mark.parametrize('processor,key,value', (
+        ('', 'fictional_argument', 'fictional_value'),
+        ('session', 'manageTransaction', True)
+))
+@pytest.mark.asyncio
+async def test_conn_default_op_args(event_loop, monkeypatch, processor, key, value):
+    mock_client_session = mock.Mock(spec=aiohttp.ClientSession)
+    mock_client_session_instance = mock.Mock(spec=aiohttp.ClientSession)
+    mock_client_session.return_value = mock_client_session_instance
+    mock_client_session_instance.ws_connect = mock.Mock(wraps=mock_ws_connect)
+    mock_client_session_instance.close = get_mock_coro(None)  # otherwise awaiting ws.close is an error
+
+    monkeypatch.setattr(aiohttp, 'ClientSession', mock_client_session)
+    monkeypatch.setattr(uuid, 'uuid4', mock.Mock(return_value=request_id))
+
+    conn = await driver.Connection.open(
+        'some_url',
+        event_loop,
+        message_serializer=serializer.GraphSONMessageSerializer,
+        provider=TestProvider
+    )
+
+    resp = await conn.submit(
+        gremlin='g.V().hasLabel("foo").count()', processor=processor, op='eval')
+    resp.close()
+    await conn.close()
+
+    submitted_bytes = conn._ws.send_bytes.call_args[0][0]
+    submitted_json = submitted_bytes[17:].decode()
+    submitted_dict = json.loads(submitted_json)
+
+    assert submitted_dict['args'][key] == value

--- a/tests/test_provider_conf.py
+++ b/tests/test_provider_conf.py
@@ -8,6 +8,7 @@ import pytest
 import aiohttp
 from aiohttp import websocket_client
 
+import goblin
 from goblin import driver
 from goblin.driver import serializer
 from goblin import provider
@@ -51,6 +52,10 @@ class TestProvider(provider.Provider):
 
         }
     }
+
+    @staticmethod
+    def get_hashable_id(val):
+        return val
 
 
 def deserialize_json_request(request):
@@ -136,3 +141,20 @@ async def test_cluster_conn_provider(event_loop):
     assert pooled_conn._conn._provider == TestProvider
 
     await cluster.close()
+
+
+@pytest.mark.asyncio
+async def test_app_cluster_provider(event_loop):
+    app = await goblin.Goblin.open(event_loop, provider=TestProvider)
+    assert app._provider is TestProvider
+    assert app._cluster.config['provider'] is TestProvider
+
+    await app.close()
+
+
+@pytest.mark.asyncio
+async def test_app_provider_hashable_id(event_loop):
+    app = await goblin.Goblin.open(event_loop, provider=TestProvider)
+    assert app._get_hashable_id is TestProvider.get_hashable_id
+
+    await app.close()


### PR DESCRIPTION
This is the beginning of the provider interface, which will be used to keep track of configuration and features that vary by provider.

I started by adding an interface for default op args -- an example is that the `manageTransaction=true` arg must be passed for eval on the session processor with DSE.

This involved adding the "provider" argument to `Connection.__init__ / Connection.open`. By default it is `TinkerGraph` if not passed.

A change is also introduced to the serializer API; the `serialize_message` method now takes a mandatory `provider` argument. The `get_op` method on `Processor` is replaced by `get_op_args` which gets the method and returns the args in one call.

I hope the tests are readable; I haven't made much use of the `unittest.mock` package before now.