### PR TITLE
removed connection kwargs from ConnectionPool.acquire

### DIFF
--- a/goblin/driver/pool.py
+++ b/goblin/driver/pool.py
@@ -169,11 +169,6 @@ class ConnectionPool:
 
     async def acquire(self):
         """**coroutine** Acquire a new connection from the pool."""
-        username = self._username
-        password = self._password
-        response_timeout = self._response_timeout
-        max_inflight = self._max_inflight
-        message_serializer = self._message_serializer
         async with self._condition:
             while True:
                 while self._available:
@@ -183,10 +178,10 @@ class ConnectionPool:
                         self._acquired.append(conn)
                         return conn
                 if len(self._acquired) < self._max_conns:
-                    conn = await self._get_connection(username, password,
-                                                      max_inflight,
-                                                      response_timeout,
-                                                      message_serializer)
+                    conn = await self._get_connection(self._username, self._password,
+                                                      self._max_inflight,
+                                                      self._response_timeout,
+                                                      self._message_serializer)
                     conn.increment_acquired()
                     self._acquired.append(conn)
                     return conn

--- a/goblin/driver/pool.py
+++ b/goblin/driver/pool.py
@@ -167,14 +167,13 @@ class ConnectionPool:
         async with self._condition:
             self._condition.notify()
 
-    async def acquire(self, username=None, password=None, max_inflight=None,
-                      response_timeout=None, message_serializer=None):
+    async def acquire(self):
         """**coroutine** Acquire a new connection from the pool."""
-        username = username or self._username
-        password = password or self._password
-        response_timeout = response_timeout or self._response_timeout
-        max_inflight = max_inflight or self._max_inflight
-        message_serializer = message_serializer or self._message_serializer
+        username = self._username
+        password = self._password
+        response_timeout = self._response_timeout
+        max_inflight = self._max_inflight
+        message_serializer = self._message_serializer
         async with self._condition:
             while True:
                 while self._available:


### PR DESCRIPTION
I realized these connection creation kwargs on ConnectionPool.acquire
were a potential issue, because while they would be used if a new
connection was created, if a connection was available it would be
acquired despite possibly having a different configuration entirely

Also, if different kwargs were passed in successive calls to acquire you could
end up with a pool of connections with different configurations and no
way of knowing which configuration you'd end up with after calling
acquire.

None of our code was using these.