### PR TITLE
Added variable indicating availability of separators keyword argument…

### DIFF
--- a/gremlin_python/structure/io/graphson.py
+++ b/gremlin_python/structure/io/graphson.py
@@ -25,10 +25,8 @@ from types import FunctionType
 
 try:
     import ujson as json
-    use_separators = False
 except ImportError:
     import json
-    use_separators = True
 
 from gremlin_python import statics
 from gremlin_python.process.traversal import Binding
@@ -69,10 +67,7 @@ class GraphSONWriter(object):
 
     @staticmethod
     def writeObject(objectData):
-        if use_separators:
-            return json.dumps(GraphSONWriter._dictify(objectData), separators=(',', ':'))
-        else:
-            return json.dumps(GraphSONWriter._dictify(objectData))
+        return json.dumps(GraphSONWriter._dictify(objectData))
 
 class GraphSONReader(object):
     @staticmethod

--- a/gremlin_python/structure/io/graphson.py
+++ b/gremlin_python/structure/io/graphson.py
@@ -25,8 +25,10 @@ from types import FunctionType
 
 try:
     import ujson as json
+    use_separators = False
 except ImportError:
     import json
+    use_separators = True
 
 from gremlin_python import statics
 from gremlin_python.process.traversal import Binding
@@ -67,8 +69,10 @@ class GraphSONWriter(object):
 
     @staticmethod
     def writeObject(objectData):
-        return json.dumps(GraphSONWriter._dictify(objectData), separators=(',', ':'))
-
+        if use_separators:
+            return json.dumps(GraphSONWriter._dictify(objectData), separators=(',', ':'))
+        else:
+            return json.dumps(GraphSONWriter._dictify(objectData))
 
 class GraphSONReader(object):
     @staticmethod


### PR DESCRIPTION
ujson doesn't have the separators keyword argument (and it looks like the maintainer doesn't wish to add this...ever), so I've added a fairly lightweight flag in the try...except import statement to account for this, and a check around the json.dumps invocation (with or without separators, depending on the flag).