### PR TITLE
Fix KeyError when using help()

### DIFF
--- a/goblin/exception.py
+++ b/goblin/exception.py
@@ -6,7 +6,7 @@ class ClientError(Exception):
     pass
 
 
-class MappingError(Exception):
+class MappingError(AttributeError):
     pass
 
 

--- a/goblin/mapper.py
+++ b/goblin/mapper.py
@@ -215,7 +215,7 @@ class Mapping:
         try:
             mapping, _ = self._ogm_properties[value]
             return mapping
-        except:
+        except KeyError:
             raise exception.MappingError(
                 "unrecognized property {} for class: {}".format(
                     value, self._element_type))


### PR DESCRIPTION
When calling Python's help() on a mapped item, there is raised KeyError with
__objclass__ being the requested key.